### PR TITLE
Arrowfunctionsfix

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -130,8 +130,8 @@
     var playButton = document.getElementById("spread");
 
     fetch(latestCountsUrl)
-      .then(res => res.json())
-      .then(res => {
+      .then(function(res) { return res.json(); })
+      .then(function(res) {
         totalCases.innerText = res[0].caseCount
         lastUpdatedDate.innerText = res[0].date
       });
@@ -196,7 +196,7 @@
         setTimeControlLabel(dates.length - 1);
       };
 
-      timeControl.addEventListener("input", () => {
+      timeControl.addEventListener("input", function() {
         setTimeControlLabel(timeControl.value);
         filterBy(dates[timeControl.value]);
       });
@@ -291,9 +291,11 @@
         //     map.getSource('cumulative').setData(res);
         // });
 
-        fetch(dataUrl).then(res => res.json()).then(res => {
+        fetch(dataUrl)
+        .then(function(res) { return res.json(); })
+        .then(function(res) {
           var datesUnsorted = [];
-          res.features.forEach(feature => {
+          res.features.forEach(function(feature) {
             var date = feature.properties.date;
             if (!datesUnsorted.includes(date) && date !== '' && date !== '2020-2-18' && date !== '2020-02-2020 - 26-02-25') {
               datesUnsorted.push(date)

--- a/app/index.html
+++ b/app/index.html
@@ -115,6 +115,18 @@
     <div id="map"></div>
   </div>
   <script type="text/javascript">
+    // polyfill for array.includes()
+    if (!Array.prototype.includes) {
+      Array.prototype.includes = function (search, start) {
+        'use strict';
+
+        if (search instanceof RegExp) {
+          throw TypeError('first argument must not be a RegExp');
+        }
+        if (start === undefined) { start = 0; }
+        return this.indexOf(search, start) !== -1;
+      };
+    }
 
     var dataUrl = './ncov2019.weekly.geojson?nocache=' + (new Date()).getTime();
     var latestCountsUrl = './latestCounts.json?nocache=' + (new Date()).getTime();
@@ -175,7 +187,7 @@
           filterBy(dates[i]);
           setTimeControlLabel(i);
           i++;
-          if(i == dates.length) {
+          if(i === dates.length) {
             clearInterval(stepMap);
           }
         }, 500);
@@ -298,7 +310,9 @@
           var datesUnsorted = [];
           res.features.forEach(function(feature) {
             var date = feature.properties.date;
-            datesUnsorted.push(date);
+            if (!datesUnsorted.includes(date)) {
+              datesUnsorted.push(date)
+            }
           });
           dates = datesUnsorted.sort();
           buildTimeControl();

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,8 @@
   <title>Novel Coronavirus (COVID-19)</title>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-  <script async defer src="https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.js" onload="initMap()"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.7.2/bluebird.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.4/fetch.min.js"></script>
   <link rel="stylesheet" type="text/css" href="css/fonts.css" />
   <link rel="stylesheet" type="text/css" href="css/styles.css?b" />
 </head>
@@ -297,9 +298,7 @@
           var datesUnsorted = [];
           res.features.forEach(function(feature) {
             var date = feature.properties.date;
-            if (!datesUnsorted.includes(date) && date !== '' && date !== '2020-2-18' && date !== '2020-02-2020 - 26-02-25') {
-              datesUnsorted.push(date)
-            }
+            datesUnsorted.push(date);
           });
           dates = datesUnsorted.sort();
           buildTimeControl();
@@ -313,6 +312,7 @@
       });
     }
   </script>
+  <script async defer src="https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.js" onload="initMap()"></script>
   <link href="https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.css" rel="stylesheet" />
 
 </body>


### PR DESCRIPTION
Fixes for IE11: remove arrow functions, add polyfills for fetch, promise, and array.includes()